### PR TITLE
Experimental GSI (READ INFO)

### DIFF
--- a/gsi.json
+++ b/gsi.json
@@ -1,0 +1,7 @@
+{
+    "DEVICE": "arm64_bgN",
+    "REPO": "https://github.com/ProjectElixir-Devices/device_phhgsi_generic.git",
+    "DIR": "device/phh/treble",
+    "BUILD_TYPE": "userdebug"
+    "IS_GSI": "yes"
+}


### PR DESCRIPTION
This is an experimental config expecting a modified version of the jenkins job, and expects jenkins to accept the "IS_GSI" variable to decide whether or not to build a system image via make/mka (if set to "yes") or to brunch it. (if set to "no")